### PR TITLE
Allow full solr query

### DIFF
--- a/service/metrics.py
+++ b/service/metrics.py
@@ -150,7 +150,7 @@ def get_record_info(**args):
             params = dict(q) # clone it
         else:
             return {"Error": "Invalid value of the 'query' parameter: %s" % q,
-                    "Status Code": 404}
+                    "Status Code": 403}
 
         # override some values of the solr query
         params['fl'] = 'bibcode'

--- a/service/tests/unittests/testExceptions.py
+++ b/service/tests/unittests/testExceptions.py
@@ -195,7 +195,7 @@ class TestBadRequests(TestCase):
             url_for('metrics'),
             content_type='application/json',
             data=json.dumps({'bibcodes': []}))
-        self.assertTrue(r.status_code == 200)
+        self.assertTrue(r.status_code == 403)
         self.assertTrue('Error' in r.json)
         self.assertTrue(r.json.get('Error') == 'Unable to get results!')
 
@@ -208,7 +208,7 @@ class TestBadRequests(TestCase):
             url_for('metrics'),
             content_type='application/json',
             data=json.dumps({'bibcodes': bibcodes}))
-        self.assertTrue(r.status_code == 200)
+        self.assertTrue(r.status_code == 403)
         self.assertTrue('Error' in r.json)
         self.assertTrue(r.json.get('Error') == 'Unable to get results!')
 
@@ -219,7 +219,7 @@ class TestBadRequests(TestCase):
             url_for('metrics'),
             content_type='application/json',
             data=json.dumps({}))
-        self.assertTrue(r.status_code == 200)
+        self.assertTrue(r.status_code == 403)
         self.assertTrue('Error' in r.json)
         self.assertTrue(r.json.get('Error') == 'Unable to get results!')
 

--- a/service/tests/unittests/testMetricsFunctions.py
+++ b/service/tests/unittests/testMetricsFunctions.py
@@ -185,7 +185,13 @@ class TestRecordInfoFunction(TestCase):
             httpretty.GET, self.app.config.get('METRICS_SOLRQUERY_URL'),
             body=request_callback)
         get_record_info(
-            bibcodes=None, query={'q': 'foo', 'fq': 'title:boo', 'rows': '5000', 'fl': 'title,foo,bar'})
+            bibcodes=None, query={'q': 'foo', 'fq': 'title:boo', 'rows': '5000', 
+                                  'fl': 'title,foo,bar'})
+        
+        res = get_record_info(
+            bibcodes=None, query=[{'q': 'foo', 'fq': 'title:boo', 'rows': '5000', 
+                                  'fl': 'title,foo,bar'}])
+        self.assertEqual(res['Status Code'], 403)
         
 class TestSelfCitationFunction(TestCase):
 

--- a/service/views.py
+++ b/service/views.py
@@ -35,19 +35,23 @@ class Metrics(Resource):
             histograms = []
         histograms = histograms or allowed_histograms
         if 'bibcodes' in request.json:
+            
+            if 'query' in request.json and request.json['query']:
+                return {'Error': 'Unable to get results!',
+                        'Error Info': 'Cannot send both bibcodes and query'}, 403
             bibcodes = map(str, request.json['bibcodes'])
             if len(bibcodes) > current_app.config.get('METRICS_MAX_SUBMITTED'):
                 return {'Error': 'Unable to get results!',
                         'Error Info': 'No results: number of submitted \
-                         bibcodes exceeds maximum number'}, 200
+                         bibcodes exceeds maximum number'}, 403
             elif len(bibcodes) == 0:
                 return {'Error': 'Unable to get results!',
-                        'Error Info': 'No bibcodes found in POST body'}, 200
+                        'Error Info': 'No bibcodes found in POST body'}, 403
         elif 'query' in request.json:
             query = request.json['query']
         else:
             return {'Error': 'Unable to get results!',
-                    'Error Info': 'Nothing to calculate metrics!'}, 200
+                    'Error Info': 'Nothing to calculate metrics!'}, 403
         results = generate_metrics(
             bibcodes=bibcodes, query=query, tori=include_tori,
             types=types, histograms=histograms)


### PR DESCRIPTION
Hi Edwin,
Because of the classes, I've abandoned the idea of creating a new 'execute_query' endpoint - cause I would have to essentitally duplicate the class, which seemed unnecessary. And also, the existing clients may be using the query (but probably aren't?)

Changes:
 * allow query to contain full specification of solr query
 * in case of exceptions, return 403 HTTP code