### PR TITLE
Bug solved: "future" articles and POST single

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ httpretty
 mock
 coveralls
 cytoolz
--e git+https://github.com/adsabs/flask-consulate@8d7e60122cbc73693ac37a5468b9be78bea774a1#egg=flask-consulate
+-e git+https://github.com/adsabs/flask-consulate@d25eb26154d9c55cd4d0f580744b6fc1add15b5e#egg=flask-consulate

--- a/service/metrics.py
+++ b/service/metrics.py
@@ -68,6 +68,8 @@ def generate_metrics(**args):
     # First retrieve the data we need for our calculations
     bibcodes, bibcodes_ref, identifiers, skipped = get_record_info(
         bibcodes=args.get('bibcodes', []), query=args.get('query', None))
+    if len(bibcodes) == 1:
+        metrics_types = ['basic', 'histograms']
     # If no identifiers were returned, return empty results
     if len(identifiers) == 0:
         return result
@@ -88,11 +90,11 @@ def generate_metrics(**args):
     if 'histograms' in metrics_types:
         hists = {}
         hist_types = args.get('histograms')
-        if 'publications' in hist_types:
+        if 'publications' in hist_types and len(identifiers) > 1:
             hists['publications'] = get_publication_histograms(identifiers)
         if 'reads' in hist_types:
             hists['reads'] = get_usage_histograms(identifiers, data=usage_data)
-        if 'downloads' in hist_types:
+        if 'downloads' in hist_types and len(identifiers) > 1:
             hists['downloads'] = get_usage_histograms(
                 identifiers, usage_type='downloads', data=usage_data)
         if 'citations' in hist_types:
@@ -486,6 +488,8 @@ def get_citation_histograms(identifiers, data=None):
         nullhist = [(y, 0) for y in range(min_year, current_year + 1)]
     except:
         nullhist = [(y, 0) for y in range(min(years), current_year + 1)]
+    if len(nullhist) == 0:
+        nullhist = [(min(years), 0)]
     # Now create the histograms with zeroes for year without values
     ch['refereed to refereed'] = merge_dictionaries(dict(nullhist), rr_hist)
     ch['refereed to nonrefereed'] = merge_dictionaries(dict(nullhist), rn_hist)

--- a/service/views.py
+++ b/service/views.py
@@ -47,6 +47,9 @@ class Metrics(Resource):
             elif len(bibcodes) == 0:
                 return {'Error': 'Unable to get results!',
                         'Error Info': 'No bibcodes found in POST body'}, 403
+            elif len(bibcodes) == 1:
+                types=['basic', 'histograms']
+                histograms=['reads', 'citations']
         elif 'query' in request.json:
             query = request.json['query']
         else:


### PR DESCRIPTION
a POST of one bibcode now triggers the "abstract view" metrics (just basic metrics and reads/citation histograms)

bug solved for one bibcode "in the future" (e.g. 2016 paper in 2015)