### PR TITLE
Output for single bibcode can now be influenced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.5
+
+* fixed POST output for single bibcode (metrics_service Github issue 81)
+
 ### 1.0.4
 
 * fixed anomalies when all papers are from the future (next year)

--- a/service/metrics.py
+++ b/service/metrics.py
@@ -68,7 +68,7 @@ def generate_metrics(**args):
     # First retrieve the data we need for our calculations
     bibcodes, bibcodes_ref, identifiers, skipped = get_record_info(
         bibcodes=args.get('bibcodes', []), query=args.get('query', None))
-    if len(bibcodes) == 1:
+    if len(bibcodes) == 1 and len(metrics_types) == 0:
         metrics_types = ['basic', 'citations', 'histograms']
     # If no identifiers were returned, return empty results
     if len(identifiers) == 0:

--- a/service/views.py
+++ b/service/views.py
@@ -54,8 +54,14 @@ class Metrics(Resource):
                         'Error Info': 'No bibcodes found in POST body'}, 403
             elif len(bibcodes) == 1:
                 current_app.logger.debug('Metrics requested for single record')
-                types=['basic', 'citations', 'histograms']
-                histograms=['reads', 'citations']
+                if len(types) > 0:
+                    types = [t for t in types if t in ['basic', 'citations', 'histograms']]
+                if len(types) == 0:
+                    types=['basic', 'citations', 'histograms']
+                if len(histograms) > 0:
+                    histograms = [h for h in histograms if h in ['reads', 'citations']]
+                if len(histograms) == 0:
+                    histograms=['reads', 'citations']
         elif 'query' in request.json:
             query = request.json['query']
             current_app.logger.info('Metrics requested for query: %s'%query)


### PR DESCRIPTION
POST request always returned same output, regardless of specifications in POST request