### PR TITLE
Convert metrics id column to use BIGINT.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 # Mac specific files
 .DS_Store
 *.swp
+.venv

--- a/alembic/versions/625ad9a0b291_upgrade_metrics_index_type.py
+++ b/alembic/versions/625ad9a0b291_upgrade_metrics_index_type.py
@@ -1,0 +1,57 @@
+"""upgrade_metrics_index_type
+
+Revision ID: 625ad9a0b291
+Revises: 78af24b0bab1
+Create Date: 2026-06-30 13:58:26.353438
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '625ad9a0b291'
+down_revision = '78af24b0bab1'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    #We do all this because altering the column in place is both slow and a blocking task. Creating the new column and then swapping names 
+    #allows users to continue accessing the table during the migration.
+    op.execute('ALTER TABLE metrics ADD COLUMN big_id BIGINT;')
+    op.execute('CREATE OR REPLACE FUNCTION set_new_id() RETURNS TRIGGER AS\n'\
+                   '$BODY$\n'\
+                   'BEGIN\n'\
+                   '\t NEW.big_id := NEW.id;\n'\
+                   '\t RETURN NEW;\n'\
+                   'END\n'\
+                   '$BODY$ LANGUAGE PLPGSQL;\n'\
+                   'CREATE TRIGGER set_new_id_trigger BEFORE INSERT OR UPDATE ON {}\n'\
+                   'FOR EACH ROW EXECUTE PROCEDURE set_new_id();\n'.format('metrics'))
+    op.execute('UPDATE metrics SET big_id=id')
+    op.execute('CREATE UNIQUE INDEX IF NOT EXISTS big_id_unique ON metrics(big_id);')
+    op.execute('ALTER TABLE metrics ADD CONSTRAINT big_id_not_null CHECK (big_id IS NOT NULL) NOT VALID;')
+    op.execute('ALTER TABLE metrics VALIDATE CONSTRAINT big_id_not_null;')
+    op.execute('ALTER TABLE metrics DROP CONSTRAINT metrics_pkey, ADD CONSTRAINT metrics_pkey PRIMARY KEY USING INDEX big_id_unique;')
+    op.execute('ALTER SEQUENCE metrics_id_seq OWNED BY metrics.big_id;')
+    op.execute("ALTER TABLE metrics ALTER COLUMN big_id SET DEFAULT nextval('metrics_id_seq');")
+    op.execute("ALTER TABLE metrics RENAME COLUMN id TO old_id;")
+    op.execute("ALTER TABLE metrics RENAME COLUMN big_id TO id;")
+    op.drop_column('metrics', 'old_id')
+    op.execute('ALTER SEQUENCE metrics_id_seq as bigint MAXVALUE 9223372036854775807')
+    op.execute('DROP TRIGGER IF EXISTS set_new_id_trigger ON metrics')
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    #This exists for completeness but know that performing this downgrade will necessarily delete data for records with IDs larger than MAXINT.
+    op.add_column('metrics', sa.Column('small_id', sa.Integer(), unique=True))
+    op.execute('DELETE FROM metrics WHERE id > 2147483647')
+    op.execute('UPDATE metrics SET small_id=id')
+    op.alter_column('metrics', 'small_id', nullable=False)
+    op.drop_constraint('metrics_pkey', 'metrics', type_='primary')
+    op.create_primary_key("metrics_pkey", "metrics", ["small_id", ])
+    op.execute('ALTER SEQUENCE metrics_id_seq OWNED BY metrics.small_id;')
+    op.execute("ALTER TABLE metrics ALTER COLUMN small_id SET DEFAULT nextval('metrics_id_seq');")
+    op.alter_column('metrics', 'id', nullable=False, new_column_name='old_id')
+    op.alter_column('metrics', 'small_id', nullable=False, new_column_name='id')
+    op.drop_column('metrics', 'old_id')
+    op.execute('ALTER SEQUENCE metrics_id_seq as int MAXVALUE 2147483647')

--- a/metrics_service/models.py
+++ b/metrics_service/models.py
@@ -6,7 +6,7 @@ Created on April 9, 2015
 from flask import current_app, request
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.sql import text
-from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, BigInteger
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine.result import ResultProxy
 from sqlalchemy.ext.declarative import declarative_base
@@ -17,7 +17,7 @@ Base = declarative_base()
 
 class MetricsModel(Base):
     __tablename__ = 'metrics'
-    id = Column(Integer, primary_key=True)
+    id = Column(BigInteger, primary_key=True)
     bibcode = Column(String, nullable=False, index=True, unique=True)
     an_citations = Column(postgresql.REAL)
     an_refereed_citations = Column(postgresql.REAL)

--- a/metrics_service/tests/test_db_functions.py
+++ b/metrics_service/tests/test_db_functions.py
@@ -7,7 +7,7 @@ sys.path.append(PROJECT_HOME)
 from flask_testing import TestCase
 from flask import request
 from flask import url_for, Flask
-from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, BigInteger
 from sqlalchemy.dialects import postgresql
 from datetime import datetime
 import glob
@@ -87,7 +87,7 @@ class TestMetricsModel(TestCase):
 
     def test_metrics_model(self):
         '''Test the guts of the metrics model'''
-        mc = [Column(Integer), # id
+        mc = [Column(BigInteger), # id
               Column(String),  # bibcode
               Column(postgresql.REAL), # an_citations
               Column(postgresql.REAL), # an_refereed_citations


### PR DESCRIPTION
Metrics DB used a standard integer for indexing columns. Apparently we have run into a situation where the number of entries in the database now exceeds the number of values for a standard integer. As a result, we cannot write or update metrics for records until the column is upgraded to support more values.